### PR TITLE
ensure stateful is unmounted before attempting to wipe stateful

### DIFF
--- a/scripts/inshim.sh
+++ b/scripts/inshim.sh
@@ -40,6 +40,7 @@ if [ -z "$cros_dev" ]; then
     sleep 1d
 fi
 stateful=$(format_part_number "$cros_dev" 1)
+umount "$stateful"
 mkfs.ext4 -F "$stateful" || fail "Failed to wipe stateful." # This only wipes the stateful partition 
 mount "$stateful" /tmp || fail "Failed to mount stateful."
 mkdir -p /tmp/unencrypted


### PR DESCRIPTION
some people have been having an issue where stateful was mounted, causing mkfs.ext4 to fail wiping stateful. retarded

idk why this is happening but just merge it so the shim works

